### PR TITLE
LaTeX support & API breaking change

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ const mat = new Gyolets([
 	[4, 5, 6],
 	[7, 8, 9]
 ], {row: 3, column: 3});
-const reducedMat = mat.reduction();
+const reducedMat = mat.reduction({
+	rapid: true,
+	verbose: false
+});
 console.log(reducedMat.toString());
 ```
 ```console
@@ -35,6 +38,9 @@ console.log(reducedMat.toString());
 0	1	2
 0	0	0
 ```
+
+## Docs
+[https://yuukitoriyama.github.io/gyolets/](https://yuukitoriyama.github.io/gyolets/)
 
 ## License
 MIT License

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@toriyama/gyolets",
-	"version": "0.9.5",
+	"version": "0.9.6",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@toriyama/gyolets",
-			"version": "0.9.5",
+			"version": "0.9.6",
 			"license": "MIT",
 			"dependencies": {
 				"cac": "^6.7.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@toriyama/gyolets",
-	"version": "0.9.4",
+	"version": "0.9.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@toriyama/gyolets",
-			"version": "0.9.4",
+			"version": "0.9.5",
 			"license": "MIT",
 			"dependencies": {
 				"cac": "^6.7.3"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@toriyama/gyolets",
 	"description": "行列簡約化ツール",
-	"version": "0.9.5",
+	"version": "0.9.6",
 	"main": "dist/main.js",
 	"bin": "dist/bin.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@toriyama/gyolets",
 	"description": "行列簡約化ツール",
-	"version": "0.9.4",
+	"version": "0.9.5",
 	"main": "dist/main.js",
 	"bin": "dist/bin.js",
 	"scripts": {
@@ -12,7 +12,7 @@
 		"build:watch": "tsc --watch",
 		"docs": "typedoc",
 		"clean": "rm -rf ./dist",
-		"prepublish": "npm run test && npm run build"
+		"prepublishOnly": "npm run test && npm run build"
 	},
 	"repository": {
 		"type": "git",

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -23,11 +23,12 @@ if (parsed.options.matrix !== undefined) {
 	const mat = new Gyolets(array, {
 		row: array.length,
 		column: array[0].length
-	}, {
+	});
+	const reductionOption = {
 		verbose: parsed.options.verbose,
 		rapid: parsed.options.rapid
-	});
+	}
 	console.log(mat.toString());
-	const result = mat.reduction();
+	const result = mat.reduction(reductionOption);
 	console.log(result.toString());
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -73,6 +73,16 @@ const elementaryRowOperation = (matrix: Gyolets, option: GyoletsConstructorOptio
 	}
 }
 
+type matrix2latexOption = "matrix" | "pmatrix" | "bmatrix" | "Bmatrix" | "vmatrix" | "Vmatrix";
+const matrix2latex = (matrix: number[][], option: matrix2latexOption): string => {
+	const latexCommand = [
+		"\\begin{" + option + "}",
+		...matrix.map(row => "\t" + row.join(" & ") + " \\" + "\\"),
+		"\\end{" + option + "}"
+	].join("\n");
+	return latexCommand;
+}
+
 export interface GyoletsConstructorOptions {
 	verbose?: boolean // trueにすると計算過程を表示するようになる
 	rapid?: boolean // trueを指定すると同時に複数の行に足し引きするようになる
@@ -123,15 +133,11 @@ export default class Gyolets {
 
 	/**
 	 * Gyolets.toLaTeX()
+	 * @param option LaTeX出力する際のデザインを指定します
 	 * @returns LaTeX形式で行列を出力します
 	 */
-	toLaTeX = (): string => {
-		const latexCommand = [
-			"\\begin{bmatrix}",
-			...this.matrix.map(row => "\t" + row.join(" & ") + " \\" + "\\"),
-			"\\end{bmatrix}"
-		].join("\n");
-		return latexCommand;
+	toLaTeX = (option?: matrix2latexOption): string => {
+		return matrix2latex(this.matrix, option || "bmatrix");
 	}
 
 	/**

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import { Vec, lcm } from "./utils";
  * @param option 行基本変形に際してオプションを指定します
  * @returns 行基本変形を施した行列オブジェクトとピボット(変形時にどの行に注目したかのヒント)を返します
  */
-const elementaryRowOperation = (matrix: Gyolets, option: GyoletsConstructorOptions): { matrix: Gyolets, pivots: [number, number][] } => {
+const elementaryRowOperation = (matrix: Gyolets, option: { verbose: boolean, rapid: boolean }): { matrix: Gyolets, pivots: [number, number][] } => {
 	// どの行のどの要素に注目して行基本変形を行なったのかを記録しておく
 	let pivots: [number, number][] = [];
 	// m行n列をイメージ
@@ -83,10 +83,6 @@ const matrix2latex = (matrix: number[][], option: matrix2latexOption): string =>
 	return latexCommand;
 }
 
-export interface GyoletsConstructorOptions {
-	verbose?: boolean // trueにすると計算過程を表示するようになる
-	rapid?: boolean // trueを指定すると同時に複数の行に足し引きするようになる
-}
 /**
  * Gyoletsクラス
  * 行列オブジェクトを作成します。
@@ -95,23 +91,17 @@ export default class Gyolets {
 	matrix: number[][];
 	rowSize: number;
 	columnSize: number;
-	options: GyoletsConstructorOptions;
 	isReduced: boolean;
 	/**
 	 * コンストラクタ
 	 * @param matrix 配列オブジェクトに変換したい二次元配列を指定します
 	 * @param matrixSize 二次元配列の大きさを指定します
-	 * @param options オプションを指定します
 	 * @param isReduced (ユーザーが指定する必要はありません)
 	 */
-	constructor(matrix: number[][], matrixSize: { row: number, column: number }, options?: GyoletsConstructorOptions, isReduced?: boolean) {
+	constructor(matrix: number[][], matrixSize: { row: number, column: number }, isReduced?: boolean) {
 		this.matrix = matrix;
 		this.rowSize = matrixSize.row;
 		this.columnSize = matrixSize.column;
-		this.options = {
-			rapid: options?.rapid ? true : false, // defaultはfalse
-			verbose: options?.verbose ? true : false // defaultはtrue
-		};
 		this.isReduced = isReduced || false;
 	}
 
@@ -145,10 +135,13 @@ export default class Gyolets {
 	 * 行基本変形を繰り返し行列の簡約化を行ないます。
 	 * @returns 簡約化済みの行列オブジェクトを返します
 	 */
-	reduction = (): Gyolets => {
-		const _processed = elementaryRowOperation(this, this.options);
+	reduction = (option?: { verbose?: boolean, rapid?: boolean, latex?: boolean }): Gyolets => {
+		const _processed = elementaryRowOperation(this, {
+			verbose: option?.verbose || true, // trueにすると計算過程を表示するようになる(defaultはtrue)
+			rapid: option?.rapid || false // trueを指定すると同時に複数の行に足し引きするようになる(defaultはfalse)
+		});
 		// verboseオプションがonになっている場合
-		if (this.options.verbose === true) {
+		if (option?.verbose === true) {
 			// ピボットを表示
 			console.log(_processed.pivots);
 			// 行基本変形を行なった行列を表示
@@ -159,7 +152,7 @@ export default class Gyolets {
 			this.isReduced = true;
 			console.log("簡約化は終了しました");
 		}
-		return this.isReduced ? this.toEchelonFrom() : this.reduction();
+		return this.isReduced ? this.toEchelonFrom() : this.reduction(option);
 	}
 
 	/**

--- a/src/main.ts
+++ b/src/main.ts
@@ -122,6 +122,19 @@ export default class Gyolets {
 	}
 
 	/**
+	 * Gyolets.toLaTeX()
+	 * @returns LaTeX形式で行列を出力します
+	 */
+	toLaTeX = (): string => {
+		const latexCommand = [
+			"\\begin{bmatrix}",
+			...this.matrix.map(row => "\t" + row.join(" & ") + " \\" + "\\"),
+			"\\end{bmatrix}"
+		].join("\n");
+		return latexCommand;
+	}
+
+	/**
 	 * Gyolets.reduction()
 	 * 行基本変形を繰り返し行列の簡約化を行ないます。
 	 * @returns 簡約化済みの行列オブジェクトを返します

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -92,6 +92,46 @@ describe("行列の簡約化", () => {
 			const reducedMat = mat.reduction();
 			expect(reducedMat.toArray()).toEqual(testCase.output);
 		})
-	})
+	});
+});
 
-})
+describe("LaTeX出力", () => {
+	const testCases: { input: number[][], output: string }[] = [
+		{
+			input: [
+				[0, 1, 0],
+				[1, 0, 0],
+				[0, 0, 1]
+			],
+			output: [
+				"\\begin{bmatrix}",
+				"\t0 & 1 & 0 \\\\",
+				"\t1 & 0 & 0 \\\\",
+				"\t0 & 0 & 1 \\\\",
+				"\\end{bmatrix}"
+			].join("\n")
+		},
+		{
+			input: [
+				[1, 5],
+				[3, 1]
+			],
+			output: [
+				"\\begin{bmatrix}",
+				"\t1 & 5 \\\\",
+				"\t3 & 1 \\\\",
+				"\\end{bmatrix}"
+			].join("\n")
+		}
+	];
+	testCases.forEach(testCase => {
+		const testName = "[" + testCase.input.map(row => `[${row.toString()}]`) + "]";
+		test(testName, () => {
+			const mat = new Gyolets(testCase.input, {
+				row: testCase.input.length,
+				column: testCase.input[0].length
+			});
+			expect(mat.toLaTeX()).toEqual(testCase.output);
+		})
+	})
+});

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -5,7 +5,7 @@ describe("階段化", () => {
 		const mat = new Gyolets([[0, 2, 0], [1, 0, 0], [0, 0, 3]], {
 			row: 3,
 			column: 3
-		}, undefined, true);
+		}, true);
 		const result = mat.toEchelonFrom();
 		expect(result.toArray()).toStrictEqual([[1, 0, 0], [0, 2, 0], [0, 0, 3]]);
 	});
@@ -13,7 +13,7 @@ describe("階段化", () => {
 		const mat = new Gyolets([[1, 2, 0], [0, 0, 0], [0, 4, 3]], {
 			row: 3,
 			column: 3
-		}, undefined, true);
+		}, true);
 		const result = mat.toEchelonFrom();
 		expect(result.toArray()).toStrictEqual([[1, 2, 0], [0, 4, 3], [0, 0, 0]]);
 	});


### PR DESCRIPTION
- LaTeXサポート
    - #1 で挙げたLaTeX出力のサポート
    - `Gyolets.toLaTeX(option)`: optionの指定で括弧のデザインを変更できる
- APIの破壊的変更
    - 従来まではGyoletsのコンストラクタで`rapid`や`verbose`オプションを指定していたが、
    - `reduction`メソッドでしか用いないため、このメソッドの引数で指定するのが自然であるとして変更
    - この変更に合わせテストコードも修正